### PR TITLE
Make context path relative to baseDirectory

### DIFF
--- a/src/main/scala/com/github/stonexx/sbt/webpack/SbtWebpack.scala
+++ b/src/main/scala/com/github/stonexx/sbt/webpack/SbtWebpack.scala
@@ -146,7 +146,7 @@ object SbtWebpack extends AutoPlugin {
       state.value.log
     )
     import DefaultJsonProtocol._
-    results.headOption.toList.flatMap(_.convertTo[Seq[String]]).map(file)
+    results.headOption.toList.flatMap(_.convertTo[Seq[String]]).map(path => baseDirectory.value / path)
   }
 
   private def relativizedPath(base: File, file: File): String =


### PR DESCRIPTION
Hi there,
I've run into an issue with the context paths used in the cache input filters.

Webpack is executed in the context of the baseDirectory, however the input filters are relative to the root directory rather than the baseDirectory.

This change corrects this and allows for configurations such as 
```
module.exports = {
  context: '../client/target/scala-2.11',
  entry: './client-fastopt.js',
  output: {
    filename: '../client/target/scala-2.11/bundle-dev.js'
  }
}
```
to work with an input filter of 
```
includeFilter in(WebpackModes.Dev, webpack) := "client-fastopt.js"
```