### PR TITLE
Use Java's native isAbsolute check

### DIFF
--- a/src/main/scala/com/github/stonexx/sbt/webpack/SbtWebpack.scala
+++ b/src/main/scala/com/github/stonexx/sbt/webpack/SbtWebpack.scala
@@ -153,7 +153,8 @@ object SbtWebpack extends AutoPlugin {
     )
     import DefaultJsonProtocol._
     results.headOption.toList.flatMap(_.convertTo[Seq[String]]).map { path =>
-      if (path.startsWith("/")) file(path)
+      val pathFile = file(path)
+      if (pathFile.isAbsolute) pathFile
       else baseDirectory.value / path
     }
   }


### PR DESCRIPTION
The old check didn't work on Windows, since absolute paths there start with \
or {Letter}:\

This fixes #14